### PR TITLE
Using explicit includes instead of globbing

### DIFF
--- a/lib/shipwire_integration.rb
+++ b/lib/shipwire_integration.rb
@@ -1,0 +1,8 @@
+$:.unshift File.dirname(__FILE__)
+
+require 'ship_wire'
+require 'shipment_entry'
+require 'shipment_tracking'
+require 'shipping_rate'
+require 'order'
+require 'inventory_status'

--- a/shipwire_endpoint.rb
+++ b/shipwire_endpoint.rb
@@ -1,8 +1,7 @@
 require "sinatra"
 require "endpoint_base"
 
-require File.expand_path(File.dirname(__FILE__) + '/lib/ship_wire.rb')
-Dir['./lib/**/*.rb'].each { |f| require f }
+require File.expand_path(File.dirname(__FILE__) + '/lib/shipwire_integration.rb')
 
 class ShipwireEndpoint < EndpointBase::Sinatra::Base
   set :logging, true


### PR DESCRIPTION
Matches up with the some of the more recent endpoint conventions and makes it easier to bolt on customizations if you can't use the out of the box extension.